### PR TITLE
fix SPINDLE_LASER_ENA_PIN when SPINDLE_LASER_ENA_PIN = 0

### DIFF
--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -210,7 +210,7 @@ public:
         enable = false;
         apply_power(0);
     }
-    #if SPINDLE_LASER_ENA_PIN
+    #if defined(SPINDLE_LASER_ENA_PIN)
       WRITE(SPINDLE_LASER_ENA_PIN, enable ? SPINDLE_LASER_ACTIVE_STATE : !SPINDLE_LASER_ACTIVE_STATE);
     #endif
     enable_state = enable;


### PR DESCRIPTION
fix SPINDLE_LASER_ENA_PIN is ignored when SPINDLE_LASER_ENA_PIN = 0 ( PA0, as example)
